### PR TITLE
Fixed Another Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ hx ./run-container.sh
 ```
 ```bash
 # Once inside the container, build Helix
-./build-helix.sh
+./build-helix-armv6l.sh
 ```
 ```bash
 # Once Helix is built, you can exit the container and copy the binary to your device.


### PR DESCRIPTION
Fixed a typo on the build instructions re: which script to use inside the container.